### PR TITLE
increase unit tests timeout threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --fix src",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",
     "pretest": "npm run build",
-    "test": "cross-env TS_NODE_PROJECT='./tests/tsconfig.json' mocha -r ts-node/register tests/index.ts",
+    "test": "cross-env TS_NODE_PROJECT='./tests/tsconfig.json' mocha -r ts-node/register tests/index.ts --timeout 5000",
     "doc": "rimraf docs && typedoc",
     "prepare": "husky install"
   },


### PR DESCRIPTION
Increase the mocha test timeout threshold from 2000ms (default) to 5000ms to ensure unit tests could be finished in action runners.

Errors as below:

```bash
  1 failing

  1) builder
       CMakeBuilderTest:
     Error: Timeout of 2000ms exceeded.
```