### PR TITLE
Fix grub-efi-amd64-signed installation failures on ci process

### DIFF
--- a/.github/workflows/shared_workflow.yml
+++ b/.github/workflows/shared_workflow.yml
@@ -17,7 +17,10 @@ jobs:
           fetch-depth: 5
 
       - name: Install system dependencies
+        # https://github.com/actions/runner-images/issues/7192
+        # https://github.com/orgs/community/discussions/47863
         run: |
+          sudo apt-mark hold grub-efi-amd64-signed
           sudo apt-get update
           sudo apt-get -y upgrade
           sudo apt-get install -y git python3 cmake curl build-essential


### PR DESCRIPTION
The CI checks of this PR failed because the it uses the old `workflows/shared_workflow.yml`  in `workflows/webinizer_ci.yml` and the changes are not applied until the PR is merged.

I have tested here https://github.com/NingW101/webinizer/commit/a6837243a3f7cbfcd95e87b2b1b2673e4235fe64 and CI jobs went well, and we can merge this RP first so that the rest PRs CI checks should get back to normal.