### PR TITLE
Support metadata conversion of builders from extension

### DIFF
--- a/documentation/extensions/develop-an-extension.rst
+++ b/documentation/extensions/develop-an-extension.rst
@@ -238,6 +238,7 @@ Below is the example code of a new builder DemoBuilder of ``webinizer-extension-
     static __type__ = "DemoBuilder";
     type = DemoBuilder.__type__;
     desc = "demo builder";
+    command = "demo builder";
     args: string[];
     id: number;
     private _proj: webinizer.Project;
@@ -254,6 +255,7 @@ Below is the example code of a new builder DemoBuilder of ``webinizer-extension-
         __type__: this.type,
         id: this.id,
         desc: this.desc,
+        command: this.command,
         args: shlex.join(this.args),
         rootBuildFilePath: this._rootBuildFilePath,
       };

--- a/extensions/webinizer-extension-demo/src/builders/demo_builder.ts
+++ b/extensions/webinizer-extension-demo/src/builders/demo_builder.ts
@@ -38,6 +38,7 @@ class DemoBuilder implements webinizer.IBuilder {
   static __type__ = "DemoBuilder";
   type = DemoBuilder.__type__;
   desc = "demo builder";
+  command = "demo builder";
   args: string[];
   id: number;
   private _proj: webinizer.Project;
@@ -54,6 +55,7 @@ class DemoBuilder implements webinizer.IBuilder {
       __type__: this.type,
       id: this.id,
       desc: this.desc,
+      command: this.command,
       args: shlex.join(this.args),
       rootBuildFilePath: this._rootBuildFilePath,
     };

--- a/src/advisors/build_step_validate.ts
+++ b/src/advisors/build_step_validate.ts
@@ -47,6 +47,7 @@ class BuildStepValidateAdvisor implements IAdvisor {
           __type__: "MakeBuilder",
           id: 0 /* set to default 0 as this will be re-set in next build*/,
           desc: "Make",
+          command: "emmake make",
           args: "clean",
           rootBuildFilePath: builder.rootBuildFilePath as string,
         };

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,7 +13,6 @@ import { buildDirTree, IDtreeJson } from "./dtree";
 import { Project, ProjectConfig, ProjectResult } from "./project";
 import { IProjectProfile } from "./project_profiles";
 import { recipeArrayFromJson, type Recipe } from "./recipe";
-// import { ALL_BUILDER_FACTORIES } from "./builder";
 import { buildStatus, type StatusType } from "./status";
 import errorCode from "./error_code";
 import { handleUploadProject, cloneProject, fetchProjectFromRegistry } from "./create_project";

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,7 +13,7 @@ import { buildDirTree, IDtreeJson } from "./dtree";
 import { Project, ProjectConfig, ProjectResult } from "./project";
 import { IProjectProfile } from "./project_profiles";
 import { recipeArrayFromJson, type Recipe } from "./recipe";
-import { ALL_BUILDER_FACTORIES } from "./builder";
+// import { ALL_BUILDER_FACTORIES } from "./builder";
 import { buildStatus, type StatusType } from "./status";
 import errorCode from "./error_code";
 import { handleUploadProject, cloneProject, fetchProjectFromRegistry } from "./create_project";
@@ -239,13 +239,7 @@ export function recommendBuildersToUse(root: string): IBuilder[] {
 export function getAllBuilders(root: string): IBuilder[] {
   validateProjectRoot(root);
   const proj = new Project(root);
-  const builders: IBuilder[] = [];
-
-  for (const bf of ALL_BUILDER_FACTORIES.factoriesMap().values()) {
-    builders.push(bf.createDefault(proj));
-  }
-
-  return builders;
+  return proj.getAllBuilders();
 }
 
 export async function disableAdvisorToUse(root: string, advisor: string): Promise<ProjectConfig> {

--- a/src/builders/cmake.ts
+++ b/src/builders/cmake.ts
@@ -61,6 +61,7 @@ class CMakeBuilder implements IBuilder {
   static __type__ = "CMakeBuilder";
   type = CMakeBuilder.__type__;
   desc = "CMake";
+  command = "emcmake cmake";
   id: number;
   args: string[];
   private _proj: IProject;
@@ -76,6 +77,7 @@ class CMakeBuilder implements IBuilder {
       __type__: this.type,
       id: this.id,
       desc: this.desc,
+      command: this.command,
       args: shlex.join(this.args),
       rootBuildFilePath: this._rootBuildFilePath,
     };
@@ -173,7 +175,7 @@ class CMakeBuilder implements IBuilder {
     }
 
     const cmd =
-      "emcmake cmake ./ " +
+      `${this.command} ./ ` +
       (this.args
         ? shlex
             .join([...new Set(this.args.map((a) => this._proj.evalTemplateLiterals(a)))])

--- a/src/builders/configure.ts
+++ b/src/builders/configure.ts
@@ -61,6 +61,7 @@ class ConfigureBuilder implements IBuilder {
   static __type__ = "ConfigureBuilder";
   type = ConfigureBuilder.__type__;
   desc = "configure";
+  command = "emconfigure ./configure";
   args: string[];
   id: number;
   private _proj: IProject;
@@ -78,6 +79,7 @@ class ConfigureBuilder implements IBuilder {
       __type__: this.type,
       id: this.id,
       desc: this.desc,
+      command: this.command,
       args: shlex.join(this.args),
       rootBuildFilePath: this._rootBuildFilePath,
     };
@@ -167,7 +169,7 @@ class ConfigureBuilder implements IBuilder {
     // run cmd
     const cmd =
       envCmds +
-      "emconfigure ./configure " +
+      `${this.command} ` +
       (this.args
         ? shlex
             .join([...new Set(this.args.map((a) => this._proj.evalTemplateLiterals(a)))])

--- a/src/builders/emcc.ts
+++ b/src/builders/emcc.ts
@@ -48,6 +48,7 @@ class EmccBuilder implements IBuilder {
   static __type__ = "EmccBuilder";
   type = EmccBuilder.__type__;
   desc = "emcc";
+  command = "emcc";
   args: string[];
   id: number;
   private _proj: IProject;
@@ -64,6 +65,7 @@ class EmccBuilder implements IBuilder {
       __type__: this.type,
       id: this.id,
       desc: this.desc,
+      command: this.command,
       args: shlex.join(this.args),
       rootBuildFilePath: this._rootBuildFilePath,
     };
@@ -94,7 +96,7 @@ class EmccBuilder implements IBuilder {
       ]),
     ];
 
-    const cmd = "emcc " + shlex.join(argsUnion).replace(/'/g, "");
+    const cmd = `${this.command} ` + shlex.join(argsUnion).replace(/'/g, "");
     log.info(`... running emcc command: ${cmd}`, dumpLog);
     const results = await H.runCommand(
       cmd,

--- a/src/builders/make.ts
+++ b/src/builders/make.ts
@@ -60,6 +60,7 @@ class MakeBuilder implements IBuilder {
   static __type__ = "MakeBuilder";
   type = MakeBuilder.__type__;
   desc = "make";
+  command = "emmake make";
   id: number;
   private _proj: IProject;
   private _rootBuildFilePath: string; // file dirname (w/o file name)
@@ -75,6 +76,7 @@ class MakeBuilder implements IBuilder {
       __type__: MakeBuilder.__type__,
       id: this.id,
       desc: this.desc,
+      command: this.command,
       args: shlex.join(this.args),
       rootBuildFilePath: this._rootBuildFilePath,
     };
@@ -143,7 +145,7 @@ class MakeBuilder implements IBuilder {
 
     const cmd =
       envCmds +
-      "emmake make -j4 " +
+      `${this.command} -j4 ` +
       (this.args
         ? shlex
             .join([...new Set(this.args.map((a) => this._proj.evalTemplateLiterals(a)))])

--- a/src/builders/native.ts
+++ b/src/builders/native.ts
@@ -47,6 +47,7 @@ class NativeBuilder implements IBuilder {
   static __type__ = "NativeBuilder";
   type = NativeBuilder.__type__;
   desc = "Run native commands without emscripten related configs";
+  command = ""; // no pre-defined command for native builder as it may vary
   args: string[];
   id: number;
   private _proj: IProject;
@@ -63,6 +64,7 @@ class NativeBuilder implements IBuilder {
       __type__: this.type,
       id: this.id,
       desc: this.desc,
+      command: this.command,
       args: this.args[0],
       rootBuildFilePath: this._rootBuildFilePath,
     };

--- a/src/error_code.ts
+++ b/src/error_code.ts
@@ -44,6 +44,7 @@ const enum errorCode {
   WEBINIZER_DIR_MV_FAIL = "WEBINIZER_DIR_MV_FAIL", // Failed to rename a directory.
   /* Builder */
   WEBINIZER_BUILDER_UNDEFINED = "WEBINIZER_BUILDER_UNDEFINED", // No builders are defined yet for building.
+  WEBINIZER_BUILDER_UNKNOWN = "WEBINIZER_BUILDER_UNKNOWN", // Unknown builder type.
   /* Advisor */
   WEBINIZER_ADVISOR_UNKNOWN = "WEBINIZER_ADVISOR_UNKNOWN", // Unknown advisor type.
   /* Advisor Pipeline */

--- a/src/project.ts
+++ b/src/project.ts
@@ -98,6 +98,14 @@ export class Project implements IProject {
     return builders;
   }
 
+  getAllBuilders(): IBuilder[] {
+    const builders: IBuilder[] = [];
+    for (const bf of ALL_BUILDER_FACTORIES.factoriesMap().values()) {
+      builders.push(bf.createDefault(this));
+    }
+    return builders;
+  }
+
   getTemplateLiterals(withMarkdown = false): string[] {
     const templates: string[] = [];
     for (const c in this.constant) {

--- a/src/schemas/config_schema.ts
+++ b/src/schemas/config_schema.ts
@@ -53,6 +53,7 @@ export const buildTargetConfigSchema = {
           __type__: { type: "string" },
           id: { type: "number" },
           desc: { type: "string" },
+          command: { type: "string" },
           args: { type: "string" },
           rootBuildFilePath: { type: "string" },
         },

--- a/tests/action_tests.ts
+++ b/tests/action_tests.ts
@@ -59,6 +59,7 @@ describe("action", () => {
         __type__: "CMakeBuilder",
         id: 1,
         desc: "cmake",
+        command: "emcmake cmake",
         args: "",
         rootBuildFilePath: "${projectRoot}",
       },

--- a/typings/webinizer.d.ts
+++ b/typings/webinizer.d.ts
@@ -569,6 +569,10 @@ declare module "webinizer" {
      */
     desc: string;
     /**
+     * The pre-defined command of the builder, used for build.
+     */
+    command: string;
+    /**
      * The overall arguments string of the builder.
      */
     args: string;
@@ -590,6 +594,10 @@ declare module "webinizer" {
      * The description of the builder.
      */
     desc: string;
+    /**
+     * The pre-defined command of the builder, used for build.
+     */
+    command: string;
     /**
      * The arguments array of the builder. Each element in the array is a argument.
      */


### PR DESCRIPTION
- add a property `command` to IBuilder to represents default build command of a builder
- dynamic creation of builder type <-> command map from all available builders