### PR TITLE
Support default keywords

### DIFF
--- a/src/project_caches/project_config.ts
+++ b/src/project_caches/project_config.ts
@@ -659,18 +659,31 @@ export class ProjectConfig extends ProjectCacheFile implements IProjectConfig {
     }
   }
 
-  get keywords(): string | undefined {
-    return this.data.keywords as string;
+  get keywords(): string[] | undefined {
+    return this.data.keywords as string[];
   }
 
-  set keywords(v: string | undefined) {
+  set keywords(v: string[] | undefined) {
     this.data = { keywords: v };
-    if (this.keywords === undefined && this.proj.meta.get("keywords") === undefined) return;
-    if (this.keywords !== ((this.proj.meta.get("keywords") || []) as string[]).join(",")) {
-      this.proj.meta.set(
-        "keywords",
-        this.keywords ? this.keywords.split(",").map((k) => k.trim()) : []
-      );
+    const equalsCheck = (a: string[], b: string[]) => {
+      return a.length === b.length && a.every((v, i) => v === b[i]);
+    };
+    if (!equalsCheck(this.keywords || [], (this.proj.meta.get("keywords") || []) as string[])) {
+      this.proj.meta.set("keywords", this.keywords);
+    }
+  }
+
+  setDefaultKeywords(words = ["webinizer"]) {
+    const currentKeywords: string[] = this.keywords || [];
+    let keywordsUpdated = false;
+    words.forEach((word) => {
+      if (!currentKeywords.length || !currentKeywords.includes(word)) {
+        currentKeywords.splice(0, 0, word);
+        if (!keywordsUpdated) keywordsUpdated = true;
+      }
+    });
+    if (keywordsUpdated) {
+      this.keywords = currentKeywords;
     }
   }
 
@@ -1213,10 +1226,8 @@ export class ProjectConfig extends ProjectCacheFile implements IProjectConfig {
         this.proj.meta.set("description", this.desc);
       }
       if (jsonKeys.includes("keywords")) {
-        this.proj.meta.set(
-          "keywords",
-          this.keywords ? this.keywords.split(",").map((k) => k.trim()) : undefined
-        );
+        this.setDefaultKeywords();
+        this.proj.meta.set("keywords", _.cloneDeep(this.keywords));
       }
       if (jsonKeys.includes("homepage")) {
         this.proj.meta.set("homepage", this.homepage);
@@ -1403,9 +1414,8 @@ export class ProjectConfig extends ProjectCacheFile implements IProjectConfig {
       this.desc = (this.proj.meta.get("description") || "") as string;
     }
     if (dotProp.has(diffContent, "keywords")) {
-      this.keywords = this.proj.meta.get("keywords")
-        ? (this.proj.meta.get("keywords") as string[]).map((k) => k.trim()).join(",")
-        : undefined;
+      this.keywords = _.cloneDeep(this.proj.meta.get("keywords") as string[]);
+      this.setDefaultKeywords();
     }
     if (dotProp.has(diffContent, "homepage")) {
       this.homepage = (this.proj.meta.get("homepage") || "") as string;

--- a/src/project_caches/project_config.ts
+++ b/src/project_caches/project_config.ts
@@ -669,12 +669,12 @@ export class ProjectConfig extends ProjectCacheFile implements IProjectConfig {
       return a.length === b.length && a.every((v, i) => v === b[i]);
     };
     if (!equalsCheck(this.keywords || [], (this.proj.meta.get("keywords") || []) as string[])) {
-      this.proj.meta.set("keywords", this.keywords);
+      this.proj.meta.set("keywords", _.cloneDeep(this.keywords));
     }
   }
 
   setDefaultKeywords(words = ["webinizer"]) {
-    const currentKeywords: string[] = this.keywords || [];
+    const currentKeywords: string[] = this.keywords ? [...this.keywords] : [];
     let keywordsUpdated = false;
     words.forEach((word) => {
       if (!currentKeywords.length || !currentKeywords.includes(word)) {
@@ -1326,6 +1326,24 @@ export class ProjectConfig extends ProjectCacheFile implements IProjectConfig {
     if (this.rawDependencies) {
       this.proj.meta.set("dependencies", _.cloneDeep(this.rawDependencies));
     }
+    /* keywords - check for default keywords */
+    this.setDefaultKeywords();
+
+    if (this.homepage) {
+      this.proj.meta.set("homepage", this.homepage);
+    }
+    if (this.bugs) {
+      this.proj.meta.set("bugs", this.bugs);
+    }
+    if (this.license) {
+      this.proj.meta.set("license", this.license);
+    }
+    if (this.author) {
+      this.proj.meta.set("author", _.cloneDeep(this.author));
+    }
+    if (this.repository) {
+      this.proj.meta.set("repository", _.cloneDeep(this.repository));
+    }
 
     /* webinizer customized fields */
     // buildTargets
@@ -1414,7 +1432,7 @@ export class ProjectConfig extends ProjectCacheFile implements IProjectConfig {
       this.desc = (this.proj.meta.get("description") || "") as string;
     }
     if (dotProp.has(diffContent, "keywords")) {
-      this.keywords = _.cloneDeep(this.proj.meta.get("keywords") as string[]);
+      this.keywords = _.cloneDeep(this.proj.meta.get("keywords") || []) as string[];
       this.setDefaultKeywords();
     }
     if (dotProp.has(diffContent, "homepage")) {

--- a/src/schemas/config_schema.ts
+++ b/src/schemas/config_schema.ts
@@ -129,7 +129,11 @@ export const configSchema = {
     },
     keywords: {
       description: "The project keywords.",
-      type: "string",
+      type: "array",
+      items: {
+        type: "string",
+        pattern: "^[A-Za-z](?:[_\\.-]?[A-Za-z0-9]+)*$",
+      },
     },
     homepage: {
       description: "The project homepage address.",

--- a/src/schemas/metadata_schema.ts
+++ b/src/schemas/metadata_schema.ts
@@ -165,6 +165,7 @@ export const metaSchema = {
       type: "array",
       items: {
         type: "string",
+        pattern: "^[A-Za-z](?:[_\\.-]?[A-Za-z0-9]+)*$",
       },
     },
     homepage: {

--- a/typings/webinizer.d.ts
+++ b/typings/webinizer.d.ts
@@ -179,7 +179,7 @@ declare module "webinizer" {
     /**
      * The project keywords.
      */
-    readonly keywords: string | undefined;
+    readonly keywords: string[] | undefined;
     /**
      * The project homepage address.
      */


### PR DESCRIPTION
Also represent the keywords in config.json using a string array instead of a string.

This is to fix #31, please test with https://github.com/intel/webinizer-webclient/pull/19.