### PR TITLE
Refactoring getFileLocation to be static CMakeBuilder method

### DIFF
--- a/src/actions/file_change.ts
+++ b/src/actions/file_change.ts
@@ -14,33 +14,6 @@ import { IAction, IJsonObject, IToJson, Project as IProject, IFileChangeManager 
 
 const log = H.getLogger("file_change");
 
-/**
- * Some errors have file:line:col encoded in the error log
- * @param s error log
- * @param reverse find the first or last pattern occurrence in error log
- * @returns FileLocation or null
- * examples: CMake Error at /home/test/tests.cmake:146 (message):
- */
-export function getFileLocation(s: string, reverse: boolean): FileLocation | null {
-  let lines = s.trimStart().split("\n");
-  if (reverse) lines = lines.reverse();
-
-  // FIXME: this doesn't support file name which contains spaces. need to be fixed
-  const re = /\b(?<file>[^:\s]+):(?<line>\d+)(:(?<col>\d+))?\b/;
-
-  for (const line of lines) {
-    const m = line.match(re);
-    if (m && m.groups) {
-      return new FileLocation(
-        m.groups.file as string,
-        parseInt(m.groups.line as string),
-        m.groups.col ? parseInt(m.groups.col as string) : 0
-      );
-    }
-  }
-  return null;
-}
-
 export class FileLocation implements IToJson {
   file: string;
   line: number;

--- a/src/builders/cmake.ts
+++ b/src/builders/cmake.ts
@@ -213,9 +213,9 @@ class CMakeBuilder implements IBuilder {
     if (reverse) lines = lines.reverse();
 
     // FIXME: this doesn't support file name which contains ':', but captures white space
-    const re = /CMake Error at \/(?<file>[^:]+):(?<line>\d+)(:(?<col>\d+))?\b/;
+    const re = /(?:CMake Error at )?(?<file>[^:]+):(?<line>\d+)(:(?<col>\d+))?\b/;
     for (const line of lines) {
-      const m = line.match(re);
+      const m = line.trimStart().match(re);
       if (m && m.groups) {
         return new FileLocation(
           m.groups.file as string,

--- a/src/builders/cmake.ts
+++ b/src/builders/cmake.ts
@@ -10,7 +10,7 @@ import * as H from "../helper";
 import { ALL_BUILDER_FACTORIES } from "../builder";
 import { checkJsonType } from "../json_factory";
 import { ErrorAdviseRequest } from "../advise_requests/common_requests";
-import { getFileLocation } from "../actions/file_change";
+import { FileLocation } from "../actions/file_change";
 import { isPrevBuildersAllNative } from "../builder";
 import { dependencyDir } from "../constants";
 import {
@@ -106,7 +106,7 @@ class CMakeBuilder implements IBuilder {
           new ErrorAdviseRequest(
             "cmake",
             err,
-            getFileLocation(err, true /*search from last*/),
+            CMakeBuilder.getFileLocation(err, true /*search from last*/),
             this.id
           )
         );
@@ -198,6 +198,33 @@ class CMakeBuilder implements IBuilder {
       log.info(`... cmake successfully!`, dumpLog);
       return true;
     }
+  }
+
+  /**
+   * Some errors have file:line:col encoded in the error log
+   * @param s error log
+   * @param reverse find the first or last pattern occurrence in error log
+   * @returns FileLocation or null
+   * examples: CMake Error at /home/test/tests.cmake:146 (message):
+   * examples: CMake Error at /home/test file name with spaces/tests.cmake:146:12 (message):
+   */
+  static getFileLocation(s: string, reverse: boolean): FileLocation | null {
+    let lines = s.trimStart().split("\n");
+    if (reverse) lines = lines.reverse();
+
+    // FIXME: this doesn't support file name which contains ':', but captures white space
+    const re = /CMake Error at \/(?<file>[^:]+):(?<line>\d+)(:(?<col>\d+))?\b/;
+    for (const line of lines) {
+      const m = line.match(re);
+      if (m && m.groups) {
+        return new FileLocation(
+          m.groups.file as string,
+          parseInt(m.groups.line as string),
+          m.groups.col ? parseInt(m.groups.col as string) : 0
+        );
+      }
+    }
+    return null;
   }
 }
 


### PR DESCRIPTION
Addressing #35 
Updated regex in getFileLocation as well
Tested out some scenarios, but edge case of filename containing ":" still exist, maybe I could get some help with that 😅 
<img width="600" alt="image" src="https://github.com/intel/webinizer/assets/70333123/5c23500b-628a-4777-a777-0bbe397c9b61">
