### PR TITLE
Handle some cases of paths with spaces

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -314,7 +314,7 @@ export async function getFileContent(root: string, name: string): Promise<string
   const relative = path.relative(root, name);
   if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
     // check file type before reading it, throw error for unsupported file format (binary, etc...)
-    const fileType = await H.runCommand(`file -b ${name}`, { silent: true });
+    const fileType = await H.runCommand(`file -b '${name}'`, { silent: true });
     if (
       fileType.code === 0 &&
       (fileType.all.includes("ASCII text") ||

--- a/src/builders/cmake.ts
+++ b/src/builders/cmake.ts
@@ -143,8 +143,10 @@ class CMakeBuilder implements IBuilder {
                 )
               ),
             ])
-            .replace(/'/g, "")
+            .replace(/'/g, "") /* remove any ' charaters from shlex */
+            .replace(/"/g, "'") /* change " -> ' to escape characters like spaces used in command */
         : "";
+
       const linkerFlags = this._proj.config.getOverallEnv("ldflags")
         ? shlex
             .join([
@@ -154,11 +156,12 @@ class CMakeBuilder implements IBuilder {
                 )
               ),
             ])
-            .replace(/'/g, "")
+            .replace(/'/g, "") /* remove any ' charaters from shlex */
+            .replace(/"/g, "'") /* change " -> ' to escape characters like spaces used in command */
         : "";
       // define install path
       const prefixFlags = this._proj.config.isLibrary
-        ? ` -DCMAKE_INSTALL_PREFIX=${this._proj.constant.projectDist}`
+        ? ` -DCMAKE_INSTALL_PREFIX="'${this._proj.constant.projectDist}'"`
         : "";
       // update project prefix in `pkgConfig` field
       if (
@@ -185,6 +188,7 @@ class CMakeBuilder implements IBuilder {
         ? shlex
             .join([...new Set(this.args.map((a) => this._proj.evalTemplateLiterals(a)))])
             .replace(/'/g, "")
+            .replace(/"/g, "'")
         : "") +
       envCmds;
     log.info(`... running emcmake command: ${cmd}`, dumpLog);

--- a/src/builders/configure.ts
+++ b/src/builders/configure.ts
@@ -103,7 +103,7 @@ class ConfigureBuilder implements IBuilder {
       [
         {
           option: "--prefix",
-          value: path.join("${projectRoot}", buildDir),
+          value: `"${path.join("${projectRoot}", buildDir)}"`,
           type: "replace",
         },
       ],
@@ -138,8 +138,10 @@ class ConfigureBuilder implements IBuilder {
                 )
               ),
             ])
-            .replace(/'/g, "")
+            .replace(/'/g, "") /* remove any ' charaters from shlex */
+            .replace(/"/g, "'") /* change " -> ' to escape characters like spaces used in command */
         : "";
+
       const linkerFlags = this._proj.config.getOverallEnv("ldflags")
         ? shlex
             .join([
@@ -149,7 +151,8 @@ class ConfigureBuilder implements IBuilder {
                 )
               ),
             ])
-            .replace(/'/g, "")
+            .replace(/'/g, "") /* remove any ' charaters from shlex */
+            .replace(/"/g, "'") /* change " -> ' to escape characters like spaces used in command */
         : "";
       envCmds =
         (compilerFlags ? `CFLAGS="${compilerFlags}" CXXFLAGS="${compilerFlags}" ` : "") +
@@ -179,6 +182,7 @@ class ConfigureBuilder implements IBuilder {
         ? shlex
             .join([...new Set(this.args.map((a) => this._proj.evalTemplateLiterals(a)))])
             .replace(/'/g, "")
+            .replace(/"/g, "'")
         : "");
     log.info(`... running configure command: ${cmd}`, dumpLog);
     const results = await H.runCommand(

--- a/src/builders/emcc.ts
+++ b/src/builders/emcc.ts
@@ -101,7 +101,7 @@ class EmccBuilder implements IBuilder {
       ]),
     ];
 
-    const cmd = `${this.command} ` + shlex.join(argsUnion).replace(/'/g, "");
+    const cmd = `${this.command} ` + shlex.join(argsUnion).replace(/'/g, "").replace(/"/g, "'");
     log.info(`... running emcc command: ${cmd}`, dumpLog);
     const results = await H.runCommand(
       cmd,

--- a/src/builders/make.ts
+++ b/src/builders/make.ts
@@ -114,8 +114,10 @@ class MakeBuilder implements IBuilder {
                 )
               ),
             ])
-            .replace(/'/g, "")
+            .replace(/'/g, "") /* remove any ' charaters from shlex */
+            .replace(/"/g, "'") /* change " -> ' to escape characters like spaces used in command */
         : "";
+
       const linkerFlags = this._proj.config.getOverallEnv("ldflags")
         ? shlex
             .join([
@@ -125,11 +127,12 @@ class MakeBuilder implements IBuilder {
                 )
               ),
             ])
-            .replace(/'/g, "")
+            .replace(/'/g, "") /* remove any ' charaters from shlex */
+            .replace(/"/g, "'") /* change " -> ' to escape characters like spaces used in command */
         : "";
       // define install path
       const prefixFlags = this._proj.config.isLibrary
-        ? `PREFIX=${this._proj.constant.projectDist} `
+        ? `PREFIX="'${this._proj.constant.projectDist}'" `
         : "";
       // update project prefix in `pkgConfig` field
       if (

--- a/src/project_caches/config_fields/configs/preload_files_config.ts
+++ b/src/project_caches/config_fields/configs/preload_files_config.ts
@@ -33,9 +33,15 @@ class PreloadFilesConfig extends BaseBuildConfig {
       const a = args[i];
       if (a.includes("--preload-file")) {
         // store local file path and mapped path in virtual FS together
-        const f = a.split(" ").pop()?.trim();
-        if (f && !localFiles.includes(f)) {
-          localFiles.push(f);
+        const rawFile = a.split("--preload-file").pop()?.trim();
+        const filePath = _.trim(rawFile, '"');
+        if (filePath && !localFiles.includes(filePath)) {
+          localFiles.push(filePath);
+          if (rawFile && (!rawFile.startsWith('"') || !rawFile.endsWith('"'))) {
+            // add " " to wrap the filePath to escape possible spaces. These " will be
+            // replaced with ' at build time.
+            args[i] = `--preload-file "${filePath}"`;
+          }
         } else {
           args[i] = "";
         }
@@ -59,7 +65,7 @@ class PreloadFilesConfig extends BaseBuildConfig {
           { option: "--preload-file", value: null, type: "deleteAll" },
           ...dedupeVal.map((f) => {
             // preload file is mapped to root of virtual FS (@/) if mapping directory is not defined
-            const opt = f.includes("@/") ? `--preload-file ${f}` : `--preload-file ${f}@/`;
+            const opt = f.includes("@/") ? `--preload-file "${f}"` : `--preload-file "${f}@/"`;
             return { option: opt, value: null, type: "replace" };
           }),
         ] as IArg[])

--- a/src/project_caches/project_result.ts
+++ b/src/project_caches/project_result.ts
@@ -133,7 +133,7 @@ export default class ProjectResult extends ProjectCacheFile {
           if (filePath) {
             if (ext === "") {
               // ensure target file is JS file rather than native binary file
-              const re = await H.runCommand(`file -b ${filePath}`, { silent: true });
+              const re = await H.runCommand(`file -b '${filePath}'`, { silent: true });
               if (re.code === 0 && re.all.includes("ASCII text, with very long lines")) {
                 // check if there is .js file exists (maybe from last build) and compare the modified date
                 if (buildFiles.map((b) => b.name).includes(targetName + ".js")) {


### PR DESCRIPTION
This is to fix #44.

Below are some scenarios that this PR will fix:

- Paths used in --preload-file option
- Paths defined in --prefix of configure build system, but this would fail in later make steps depends on how the makefile is generated. If the makefile doesn't handle spaces in paths, the build fails as well.

For above two cases, we wrap the possible paths with " " (to not mix with the general handling of character escape from shlex), and replace all the " with ' to make it work at build time.

- Paths used in `file` command: for this case, just wrap the file path used in the command with ' ' directly.