### PR TITLE
Ensure the updated envs value is used when updating multiple fields from envs

### DIFF
--- a/src/project_caches/project_config.ts
+++ b/src/project_caches/project_config.ts
@@ -351,12 +351,12 @@ class ProjectBuildConfig implements IProjectBuildConfig {
   }
 
   updateOptionsFromEnvs(currentEnv: EnvType) {
-    const envFlags = this.getEnv(currentEnv).trim();
     if (this.options) {
       const opts = Object.keys(this.options) as BuildOptionType[];
       opts.forEach((opt) => {
         const optClass = this.options ? this.options[opt] : null;
         if (optClass && optClass.updateFromEnvs) {
+          const envFlags = this.getEnv(currentEnv).trim();
           const envUpdateSet = optClass.updateFromEnvs(currentEnv, envFlags);
           this.save();
           (Object.keys(envUpdateSet) as EnvType[]).forEach((env) => {
@@ -371,12 +371,12 @@ class ProjectBuildConfig implements IProjectBuildConfig {
 
   updateConfigsFromEnvs(currentEnv: EnvType) {
     if (currentEnv === "ldflags") {
-      const envFlags = this.getEnv("ldflags").trim();
       if (this.configFields) {
         const fields = Object.keys(this.configFields) as BuildConfigType[];
         fields.forEach((field) => {
           const configClass = this.configFields ? this.configFields[field] : null;
           if (configClass && configClass.updateFromEnvs) {
+            const envFlags = this.getEnv("ldflags").trim();
             const updatedEnvsFlags = configClass.updateFromEnvs(currentEnv, envFlags);
             this.save();
             this.setEnv("ldflags", updatedEnvsFlags);


### PR DESCRIPTION
Steps to test:
1. Set `func1,func2` to `Exported functions`
2. Update the value of `-sEXPORTED_FUNCTIONS` to `_func1,_func2,_func2` in `Linker flags`

Without the PR:
`-sEXPORTED_FUNCTIONS=_func1,_func2,_func2` is updated in Linker flags, which contains the duplicated `_func2`.

With the PR:
`-sEXPORTED_FUNCTIONS=_func1,_func2` is in Linker flags without duplication, which is the expected result.